### PR TITLE
Fix typo in gatsby-node.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,7 @@ exports.onCreateWebpackConfig = (
       sourceMap: !PRODUCTION,
       sassOptions: {
         ...sassOptions,
-        outputStyle: 'comptact',
+        outputStyle: 'compact',
       },
     },
   };


### PR DESCRIPTION
'sass-loader' outputStyle: 'comptact' -> 'compact'